### PR TITLE
Feature/127 createtransaction 시 userid 1로 들어가는 에러 해결

### DIFF
--- a/MoneyDefenseJGS/src/api/transactionApi.js
+++ b/MoneyDefenseJGS/src/api/transactionApi.js
@@ -60,3 +60,18 @@ export const getAllTransactions = async () => {
   const { data } = await axios.get('/Transaction')
   return data
 }
+
+/**
+ * 특정 사용자(userId)의 거래 내역을 가져오는 함수
+ * @param {string} userId - 조회할 사용자의 ID
+ * @returns {Promise<AxiosResponse>} 해당 사용자의 거래 데이터 배열
+ */
+export const getTransactionsByUserId = async (userId) => {
+  try {
+    const response = await axios.get(`/Transaction?userid=${userId}`)
+    return response.data
+  } catch (error) {
+    console.error('사용자 거래 조회 실패:', error)
+    throw error
+  }
+}

--- a/MoneyDefenseJGS/src/pages/transaction/input/TransactionCreatePage.vue
+++ b/MoneyDefenseJGS/src/pages/transaction/input/TransactionCreatePage.vue
@@ -160,7 +160,7 @@ onMounted(async () => {
 async function handleSubmit() {
   const now = new Date().toISOString().slice(0, 16)
   const payload = {
-    userid: store.userid,
+    userid: localStorage.getItem('userId'),
     date: store.date,
     type: store.type,
     category: store.category,

--- a/MoneyDefenseJGS/src/stores/transactionStore.js
+++ b/MoneyDefenseJGS/src/stores/transactionStore.js
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia'
 export const useTransactionStore = defineStore('transaction', {
   state: () => ({
     // id: '',
-    userid: '1', // 로그인 사용자 또는 기본값으로 설정
+    userid: '', // 로그인 사용자 또는 기본값으로 설정
     date: '',
     type: '',
     category: '',


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
createTransaction 시 localstorage에 저장된 userId에 해당하는 Transaction만 불러오도록 수정

## 관련 ISSUE

<!---- 아래 키워드를 사용해 연관된 이슈를 자동으로 닫을 수 있습니다. (머지 시 자동 닫힘) -->
<!-- EX) Closes #456 -->

- closes #127 

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] main이 아닌 develop에 merge하고 있습니다.
